### PR TITLE
LPS-88702

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/package-lock.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package-lock.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
 			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
 			"dev": true,
 			"requires": {
@@ -14,23 +14,23 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+			"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0",
-				"@babel/generator": "7.1.3",
-				"@babel/helpers": "7.1.2",
-				"@babel/parser": "7.1.3",
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.4",
-				"@babel/types": "7.1.3",
+				"@babel/generator": "7.3.2",
+				"@babel/helpers": "7.3.1",
+				"@babel/parser": "7.3.2",
+				"@babel/template": "7.2.2",
+				"@babel/traverse": "7.2.3",
+				"@babel/types": "7.3.2",
 				"convert-source-map": "1.6.0",
-				"debug": "3.2.6",
-				"json5": "0.5.1",
+				"debug": "4.1.1",
+				"json5": "2.1.0",
 				"lodash": "4.17.11",
-				"resolve": "1.8.1",
+				"resolve": "1.10.0",
 				"semver": "5.6.0",
 				"source-map": "0.5.7"
 			},
@@ -45,13 +45,13 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-					"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+					"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3",
-						"jsesc": "2.5.1",
+						"@babel/types": "7.3.2",
+						"jsesc": "2.5.2",
 						"lodash": "4.17.11",
 						"source-map": "0.5.7",
 						"trim-right": "1.0.1"
@@ -64,8 +64,8 @@
 					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "7.0.0",
-						"@babel/template": "7.1.2",
-						"@babel/types": "7.1.3"
+						"@babel/template": "7.2.2",
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -74,7 +74,7 @@
 					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3"
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -83,7 +83,7 @@
 					"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3"
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/highlight": {
@@ -92,43 +92,43 @@
 					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
+						"chalk": "2.4.2",
 						"esutils": "2.0.2",
 						"js-tokens": "4.0.0"
 					}
 				},
 				"@babel/template": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-					"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "7.0.0",
-						"@babel/parser": "7.1.3",
-						"@babel/types": "7.1.3"
+						"@babel/parser": "7.3.2",
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-					"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+					"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "7.0.0",
-						"@babel/generator": "7.1.3",
+						"@babel/generator": "7.3.2",
 						"@babel/helper-function-name": "7.1.0",
 						"@babel/helper-split-export-declaration": "7.0.0",
-						"@babel/parser": "7.1.3",
-						"@babel/types": "7.1.3",
-						"debug": "3.2.6",
-						"globals": "11.8.0",
+						"@babel/parser": "7.3.2",
+						"@babel/types": "7.3.2",
+						"debug": "4.1.1",
+						"globals": "11.10.0",
 						"lodash": "4.17.11"
 					}
 				},
 				"@babel/types": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-					"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+					"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
 					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
@@ -146,9 +146,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -157,18 +157,18 @@
 					}
 				},
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.1"
 					}
 				},
 				"globals": {
-					"version": "11.8.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 					"dev": true
 				},
 				"js-tokens": {
@@ -178,9 +178,24 @@
 					"dev": true
 				},
 				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
 				"ms": {
@@ -208,28 +223,28 @@
 		},
 		"@babel/generator": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
 			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.44",
-				"jsesc": "2.5.1",
+				"jsesc": "2.5.2",
 				"lodash": "4.17.11",
 				"source-map": "0.5.7",
 				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helper-function-name": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
 			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
 			"dev": true,
 			"requires": {
@@ -240,7 +255,7 @@
 		},
 		"@babel/helper-get-function-arity": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
 			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
 			"dev": true,
 			"requires": {
@@ -249,7 +264,7 @@
 		},
 		"@babel/helper-split-export-declaration": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
 			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
 			"dev": true,
 			"requires": {
@@ -257,14 +272,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-			"integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
+			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.4",
-				"@babel/types": "7.1.3"
+				"@babel/template": "7.2.2",
+				"@babel/traverse": "7.2.3",
+				"@babel/types": "7.3.2"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -277,13 +292,13 @@
 					}
 				},
 				"@babel/generator": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
-					"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+					"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3",
-						"jsesc": "2.5.1",
+						"@babel/types": "7.3.2",
+						"jsesc": "2.5.2",
 						"lodash": "4.17.11",
 						"source-map": "0.5.7",
 						"trim-right": "1.0.1"
@@ -296,8 +311,8 @@
 					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "7.0.0",
-						"@babel/template": "7.1.2",
-						"@babel/types": "7.1.3"
+						"@babel/template": "7.2.2",
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/helper-get-function-arity": {
@@ -306,7 +321,7 @@
 					"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3"
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -315,7 +330,7 @@
 					"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "7.1.3"
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/highlight": {
@@ -324,43 +339,43 @@
 					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
+						"chalk": "2.4.2",
 						"esutils": "2.0.2",
 						"js-tokens": "4.0.0"
 					}
 				},
 				"@babel/template": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-					"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "7.0.0",
-						"@babel/parser": "7.1.3",
-						"@babel/types": "7.1.3"
+						"@babel/parser": "7.3.2",
+						"@babel/types": "7.3.2"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
-					"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+					"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "7.0.0",
-						"@babel/generator": "7.1.3",
+						"@babel/generator": "7.3.2",
 						"@babel/helper-function-name": "7.1.0",
 						"@babel/helper-split-export-declaration": "7.0.0",
-						"@babel/parser": "7.1.3",
-						"@babel/types": "7.1.3",
-						"debug": "3.2.6",
-						"globals": "11.8.0",
+						"@babel/parser": "7.3.2",
+						"@babel/types": "7.3.2",
+						"debug": "4.1.1",
+						"globals": "11.10.0",
 						"lodash": "4.17.11"
 					}
 				},
 				"@babel/types": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
-					"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+					"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
 					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
@@ -378,9 +393,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -389,18 +404,18 @@
 					}
 				},
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.1"
 					}
 				},
 				"globals": {
-					"version": "11.8.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 					"dev": true
 				},
 				"js-tokens": {
@@ -410,9 +425,9 @@
 					"dev": true
 				},
 				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 					"dev": true
 				},
 				"ms": {
@@ -440,11 +455,11 @@
 		},
 		"@babel/highlight": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
 			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"esutils": "2.0.2",
 				"js-tokens": "3.0.2"
 			},
@@ -459,9 +474,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -481,14 +496,14 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+			"integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
 			"dev": true
 		},
 		"@babel/template": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
 			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
 			"dev": true,
 			"requires": {
@@ -500,7 +515,7 @@
 			"dependencies": {
 				"babylon": {
 					"version": "7.0.0-beta.44",
-					"resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
 					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
 					"dev": true
 				}
@@ -508,7 +523,7 @@
 		},
 		"@babel/traverse": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
 			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
 			"dev": true,
 			"requires": {
@@ -519,14 +534,14 @@
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
 				"debug": "3.2.6",
-				"globals": "11.8.0",
+				"globals": "11.10.0",
 				"invariant": "2.2.4",
 				"lodash": "4.17.11"
 			},
 			"dependencies": {
 				"babylon": {
 					"version": "7.0.0-beta.44",
-					"resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
 					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
 					"dev": true
 				},
@@ -540,9 +555,9 @@
 					}
 				},
 				"globals": {
-					"version": "11.8.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 					"dev": true
 				},
 				"ms": {
@@ -555,7 +570,7 @@
 		},
 		"@babel/types": {
 			"version": "7.0.0-beta.44",
-			"resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
 			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 			"dev": true,
 			"requires": {
@@ -583,10 +598,43 @@
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
-			"integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
+		},
+		"@types/node": {
+			"version": "10.12.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
+			"integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
+			"dev": true
+		},
+		"@types/unist": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.2.tgz",
+			"integrity": "sha512-iHI60IbyfQilNubmxsq4zqSjdynlmc2Q/QvH9kjzg9+CCYVVzq1O6tc7VBzSygIwnmOt07w80IG6HDQvjv3Liw==",
+			"dev": true
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "10.12.21",
+				"@types/unist": "2.0.2",
+				"@types/vfile-message": "1.0.1"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "10.12.21",
+				"@types/unist": "2.0.2"
+			}
 		},
 		"abab": {
 			"version": "2.0.0",
@@ -602,7 +650,7 @@
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
@@ -611,7 +659,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
-					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
 					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
 					"dev": true
 				}
@@ -645,9 +693,9 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -687,6 +735,7 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -716,7 +765,7 @@
 			"dev": true,
 			"requires": {
 				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0"
+				"es-abstract": "1.13.0"
 			}
 		},
 		"array-union": {
@@ -738,7 +787,8 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -765,6 +815,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
 		"async": {
@@ -796,28 +852,28 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.2.0.tgz",
-			"integrity": "sha512-OuxUyTvzRe9EvKyouPqfr8QUkQ0pH400NOFzI1LFINO8zwgJr7ZTybLql03P//LjR0iWile2lCoy2vRTRSFpMw==",
+			"version": "9.4.7",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.7.tgz",
+			"integrity": "sha512-qS5wW6aXHkm53Y4z73tFGsUhmZu4aMPV9iHXYlF0c/wxjknXNHuj/1cIQb+6YH692DbJGGWcckAXX+VxKvahMA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "4.2.1",
-				"caniuse-lite": "1.0.30000892",
+				"browserslist": "4.4.1",
+				"caniuse-lite": "1.0.30000935",
 				"normalize-range": "0.1.2",
 				"num2fraction": "1.2.2",
-				"postcss": "7.0.5",
+				"postcss": "7.0.14",
 				"postcss-value-parser": "3.3.1"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.2.1.tgz",
-					"integrity": "sha512-1oO0c7Zhejwd+LXihS89WqtKionSbz298rJZKJgfrHIZhrV8AC15gw553VcB0lcEugja7IhWD7iAlrsamfYVPA==",
+					"version": "4.4.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
+					"integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "1.0.30000892",
-						"electron-to-chromium": "1.3.79",
-						"node-releases": "1.0.0-alpha.14"
+						"caniuse-lite": "1.0.30000935",
+						"electron-to-chromium": "1.3.113",
+						"node-releases": "1.1.7"
 					}
 				}
 			}
@@ -911,7 +967,7 @@
 			"dependencies": {
 				"babylon": {
 					"version": "7.0.0-beta.44",
-					"resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
 					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
 					"dev": true
 				}
@@ -1089,12 +1145,12 @@
 			}
 		},
 		"babel-plugin-name-amd-modules": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.5.0.tgz",
-			"integrity": "sha512-XjGawxo/r1mEyJeD9rdZ7FR736Jboj+oGfQnIU0XNtB2vFVVpnxDzf0CIbUu6k0wsgWyz3sUrg2zQJ9n+uX1JA==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.6.2.tgz",
+			"integrity": "sha512-O7eIf0wjS/onyKDQZb6+8U9ShmoqnO7Y4BPXeyKlMa8c5gczjusYpBEGyDC4R/GhK0MJe3Wj3Zm5i6pH2KqlAA==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0",
+				"liferay-npm-build-tools-common": "2.6.2",
 				"read-json-sync": "1.1.1"
 			},
 			"dependencies": {
@@ -1104,27 +1160,27 @@
 					"integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "4.1.15"
 					}
 				}
 			}
 		},
 		"babel-plugin-namespace-amd-define": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.5.0.tgz",
-			"integrity": "sha512-XkPellLzxLaNoizmNfz6dcQFJJya4VirNaUeMR1X2IEIodH7Sp1wDNDYvWmXRDy/6rJ2vfLu8AEiJ2mc4BkYsA==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.6.2.tgz",
+			"integrity": "sha512-KnJrqYiq5bcZl7yuf80CcCqOHp6RfCqhILsrqkxWr7V8u4A6RL3mSiJ7dyhV52AmxqW5larWFL8ynX0XRDOeOQ==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"liferay-npm-build-tools-common": "2.6.2"
 			}
 		},
 		"babel-plugin-namespace-modules": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.5.0.tgz",
-			"integrity": "sha512-1Nlnpd5urRdK/k6dJiREDJxFpw1vEOmlO7wUGWM2l5HrsYHka21ZvHUT4i/Isb2NuOn9lqsmoqlpmqztrHm7yw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.6.2.tgz",
+			"integrity": "sha512-N1h9copSN5eZ5gMTJ4QsHajmwfzy5TAV1n3PMAUi7HSi8Wg7oEYpPWWKzKZtDl3sosUTcVa/RX1XvRnhkPGfHw==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0",
+				"liferay-npm-build-tools-common": "2.6.2",
 				"read-json-sync": "1.1.1"
 			},
 			"dependencies": {
@@ -1134,29 +1190,29 @@
 					"integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "4.1.15"
 					}
 				}
 			}
 		},
 		"babel-plugin-normalize-requires": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.5.0.tgz",
-			"integrity": "sha512-xBZhXQQ8dpcnctFZMqv01jtaF3DvkhNRRx9ZzfpbrjgVMn/qpPXDnC1rRzvz6dfxTURMhmnbJwMjJ4jJ1adLUw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.6.2.tgz",
+			"integrity": "sha512-igvOZ7j1pargM5lXDne4rLC88yYN8y9Qwjpr4gVsmIkI9qo6zOF/sE/dkRpxMOYyULC7V5ULASU/CjN1wRs7DA==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"liferay-npm-build-tools-common": "2.6.2"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
 			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
 			"dev": true
 		},
@@ -1448,13 +1504,13 @@
 			}
 		},
 		"babel-plugin-wrap-modules-amd": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.5.0.tgz",
-			"integrity": "sha512-s3wmFihU71Xnc7OUkKXJRAyI0RnwtpxlEjSSPgML/xTO+o3POlYm2xGraxKDU+N9PuhxLWL9OA01LScMKBNkJQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.6.2.tgz",
+			"integrity": "sha512-4pVqGfvvINO9sXk2Iv/35D+CDRwdCm7/EJlu2vmSeQQ+wE5rDotdNBw3sVswyHOD3cfCmLZJ8fQWQM7GBUVkjg==",
 			"dev": true,
 			"requires": {
 				"babel-template": "6.26.0",
-				"liferay-npm-build-tools-common": "2.5.0",
+				"liferay-npm-build-tools-common": "2.6.2",
 				"read-json-sync": "1.1.1"
 			},
 			"dependencies": {
@@ -1464,7 +1520,7 @@
 					"integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "4.1.15"
 					}
 				}
 			}
@@ -1476,7 +1532,7 @@
 			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
+				"core-js": "2.6.4",
 				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
@@ -1527,17 +1583,17 @@
 			}
 		},
 		"babel-preset-liferay-standard": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.5.0.tgz",
-			"integrity": "sha512-yATMH5MxXxJi3QsBgGHSetPSrFgMlu0fGK4O6xYWaZMgO+2QzgBzxF1gIuE3jbEy8tz7BoLehPC5/abwJHG6DQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.6.2.tgz",
+			"integrity": "sha512-p2Dy77fzNmLNLbROk06Z01vtEvx9k8Mcs0zIjuBN331F/jFsWWP7sbINI/kHWjQDxgMBWj6PJiLQ/oa6j3mSoQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-name-amd-modules": "2.5.0",
-				"babel-plugin-namespace-amd-define": "2.5.0",
-				"babel-plugin-namespace-modules": "2.5.0",
-				"babel-plugin-normalize-requires": "2.5.0",
+				"babel-plugin-name-amd-modules": "2.6.2",
+				"babel-plugin-namespace-amd-define": "2.6.2",
+				"babel-plugin-namespace-modules": "2.6.2",
+				"babel-plugin-normalize-requires": "2.6.2",
 				"babel-plugin-transform-node-env-inline": "0.2.0",
-				"babel-plugin-wrap-modules-amd": "2.5.0"
+				"babel-plugin-wrap-modules-amd": "2.6.2"
 			}
 		},
 		"babel-register": {
@@ -1548,7 +1604,7 @@
 			"requires": {
 				"babel-core": "6.26.3",
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
+				"core-js": "2.6.4",
 				"home-or-tmp": "2.0.0",
 				"lodash": "4.17.11",
 				"mkdirp": "0.5.1",
@@ -1561,7 +1617,7 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
+				"core-js": "2.6.4",
 				"regenerator-runtime": "0.11.1"
 			}
 		},
@@ -1702,22 +1758,22 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
+			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
 			"dev": true,
 			"optional": true
 		},
 		"bluebird": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
 			"dev": true
 		},
 		"bootstrap": {
-			"version": "3.3.7",
-			"resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
-			"integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.0.tgz",
+			"integrity": "sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw=="
 		},
 		"boxen": {
 			"version": "1.3.0",
@@ -1727,11 +1783,11 @@
 			"requires": {
 				"ansi-align": "2.0.0",
 				"camelcase": "4.1.0",
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"cli-boxes": "1.0.0",
 				"string-width": "2.1.1",
 				"term-size": "1.2.0",
-				"widest-line": "2.0.0"
+				"widest-line": "2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1744,9 +1800,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -1780,6 +1836,7 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -1792,20 +1849,14 @@
 			"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "1.0.30000892",
-				"electron-to-chromium": "1.3.79"
+				"caniuse-lite": "1.0.30000935",
+				"electron-to-chromium": "1.3.113"
 			}
 		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
 		"cache-base": {
@@ -1839,19 +1890,28 @@
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
 			"dev": true
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "2.0.0"
 			}
 		},
 		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 			"dev": true
 		},
 		"camelcase": {
@@ -1872,9 +1932,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000892",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000892.tgz",
-			"integrity": "sha512-X9rxMaWZNbJB5qjkDqPtNv/yfViTeUL6ILk0QJNxLV3OhKC5Acn5vxsuUvllR6B48mog8lmS+whwHq/QIYSL9w==",
+			"version": "1.0.30000935",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
+			"integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ==",
 			"dev": true
 		},
 		"capture-stack-trace": {
@@ -1897,7 +1957,7 @@
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
@@ -1945,17 +2005,17 @@
 			"dev": true,
 			"requires": {
 				"babel-eslint": "8.2.6",
-				"bluebird": "3.5.2",
+				"bluebird": "3.5.3",
 				"cli": "1.0.1",
 				"cli-color-keywords": "0.0.1",
 				"configstore": "3.1.2",
 				"content-formatter": "2.0.2",
 				"content-logger": "1.0.3",
 				"content-logger-handlebars-helpers": "0.0.3",
-				"cosmiconfig": "5.0.6",
+				"cosmiconfig": "5.0.7",
 				"drip": "1.4.0",
 				"eslint": "4.19.1",
-				"eslint-plugin-react": "7.11.1",
+				"eslint-plugin-react": "7.12.4",
 				"falafel": "1.2.0",
 				"getobject": "0.1.0",
 				"glob": "7.1.3",
@@ -1966,7 +2026,7 @@
 				"optimist": "0.6.1",
 				"roolz": "1.0.2",
 				"string-sub": "0.0.1",
-				"stylelint": "9.6.0",
+				"stylelint": "9.10.1",
 				"stylelint-order": "0.8.1",
 				"update-notifier": "2.5.0"
 			}
@@ -1980,7 +2040,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
+				"fsevents": "1.2.7",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -2058,7 +2118,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
 					"dev": true
 				}
@@ -2209,7 +2269,7 @@
 				"env-paths": "1.0.0",
 				"make-dir": "1.3.0",
 				"pkg-up": "2.0.0",
-				"write-file-atomic": "2.3.0"
+				"write-file-atomic": "2.4.2"
 			}
 		},
 		"configstore": {
@@ -2219,10 +2279,10 @@
 			"dev": true,
 			"requires": {
 				"dot-prop": "4.2.0",
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"make-dir": "1.3.0",
 				"unique-string": "1.0.0",
-				"write-file-atomic": "2.3.0",
+				"write-file-atomic": "2.4.2",
 				"xdg-basedir": "3.0.0"
 			}
 		},
@@ -2254,7 +2314,7 @@
 					"dev": true,
 					"requires": {
 						"cli-color-keywords": "0.0.1",
-						"handlebars": "4.0.12",
+						"handlebars": "4.1.0",
 						"lodash": "4.17.11"
 					}
 				}
@@ -2267,7 +2327,7 @@
 			"dev": true,
 			"requires": {
 				"cli-color-keywords": "0.0.1",
-				"handlebars": "4.0.12",
+				"handlebars": "4.1.0",
 				"lodash": "4.17.11"
 			}
 		},
@@ -2287,9 +2347,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+			"integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2298,13 +2358,14 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
 			"dev": true,
 			"requires": {
+				"import-fresh": "2.0.0",
 				"is-directory": "0.3.1",
-				"js-yaml": "3.12.0",
+				"js-yaml": "3.12.1",
 				"parse-json": "4.0.0"
 			}
 		},
@@ -2323,7 +2384,7 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
+				"lru-cache": "4.1.5",
 				"shebang-command": "1.2.0",
 				"which": "1.3.1"
 			}
@@ -2353,13 +2414,13 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
-			"integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
 				"abab": "2.0.0",
-				"whatwg-mimetype": "2.2.0",
+				"whatwg-mimetype": "2.3.0",
 				"whatwg-url": "7.0.0"
 			}
 		},
@@ -2476,29 +2537,6 @@
 				}
 			}
 		},
-		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true,
-			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.1",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.2"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
-			}
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2515,12 +2553,11 @@
 			}
 		},
 		"dir-glob": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
 				"path-type": "3.0.0"
 			}
 		},
@@ -2540,7 +2577,7 @@
 			"dev": true,
 			"requires": {
 				"domelementtype": "1.1.3",
-				"entities": "1.1.1"
+				"entities": "1.1.2"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -2552,9 +2589,9 @@
 			}
 		},
 		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
 		"domhandler": {
@@ -2563,7 +2600,7 @@
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0"
+				"domelementtype": "1.3.1"
 			}
 		},
 		"domutils": {
@@ -2573,7 +2610,7 @@
 			"dev": true,
 			"requires": {
 				"dom-serializer": "0.1.0",
-				"domelementtype": "1.3.0"
+				"domelementtype": "1.3.1"
 			}
 		},
 		"dot-prop": {
@@ -2611,15 +2648,21 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.79",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.79.tgz",
-			"integrity": "sha512-LQdY3j4PxuUl6xfxiFruTSlCniTrTrzAd8/HfsLEMi0PUpaQ0Iy+Pr4N4VllDYjs0Hyu2lkTbvzqlG+PX9NsNw==",
+			"version": "1.3.113",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+			"integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
 		"entities": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
 			"dev": true
 		},
 		"env-paths": {
@@ -2638,16 +2681,17 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.2.0",
 				"function-bind": "1.1.1",
 				"has": "1.0.3",
 				"is-callable": "1.1.4",
-				"is-regex": "1.0.4"
+				"is-regex": "1.0.4",
+				"object-keys": "1.0.12"
 			}
 		},
 		"es-to-primitive": {
@@ -2663,7 +2707,7 @@
 		},
 		"es6-promise": {
 			"version": "3.0.2",
-			"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
 			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
 			"dev": true
 		},
@@ -2675,13 +2719,13 @@
 		},
 		"eslint": {
 			"version": "4.19.1",
-			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"concat-stream": "1.6.2",
 				"cross-spawn": "5.1.0",
 				"debug": "3.2.6",
@@ -2694,12 +2738,12 @@
 				"file-entry-cache": "2.0.0",
 				"functional-red-black-tree": "1.0.1",
 				"glob": "7.1.3",
-				"globals": "11.8.0",
+				"globals": "11.10.0",
 				"ignore": "3.3.10",
 				"imurmurhash": "0.1.4",
 				"inquirer": "3.3.0",
 				"is-resolvable": "1.1.0",
-				"js-yaml": "3.12.0",
+				"js-yaml": "3.12.1",
 				"json-stable-stringify-without-jsonify": "1.0.1",
 				"levn": "0.3.0",
 				"lodash": "4.17.11",
@@ -2709,7 +2753,7 @@
 				"optionator": "0.8.2",
 				"path-is-inside": "1.0.2",
 				"pluralize": "7.0.0",
-				"progress": "2.0.0",
+				"progress": "2.0.3",
 				"regexpp": "1.1.0",
 				"require-uncached": "1.0.3",
 				"semver": "5.6.0",
@@ -2735,9 +2779,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -2755,9 +2799,9 @@
 					}
 				},
 				"globals": {
-					"version": "11.8.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 					"dev": true
 				},
 				"ms": {
@@ -2787,16 +2831,18 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+			"version": "7.12.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+			"integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
 			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3",
 				"doctrine": "2.1.0",
 				"has": "1.0.3",
 				"jsx-ast-utils": "2.0.1",
-				"prop-types": "15.6.2"
+				"object.fromentries": "2.0.0",
+				"prop-types": "15.6.2",
+				"resolve": "1.10.0"
 			}
 		},
 		"eslint-scope": {
@@ -2896,6 +2942,7 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -2905,6 +2952,7 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"fill-range": "2.2.4"
 			}
@@ -2938,7 +2986,7 @@
 		},
 		"external-editor": {
 			"version": "2.2.0",
-			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
@@ -2952,6 +3000,7 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2976,7 +3025,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "1.2.2",
-					"resolved": "http://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
 					"integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
 					"dev": true
 				},
@@ -2995,13 +3044,13 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.3.tgz",
-			"integrity": "sha512-NiX+JXjnx43RzvVFwRWfPKo4U+1BrK5pJPsHQdKMlLoFHrrGktXglQhHliSihWAq+m1z6fHk3uwGHrtRbS9vLA==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
 			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "2.2.1",
-				"@nodelib/fs.stat": "1.1.2",
+				"@nodelib/fs.stat": "1.1.3",
 				"glob-parent": "3.1.0",
 				"is-glob": "4.0.0",
 				"merge2": "1.2.3",
@@ -3347,7 +3396,7 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
+				"flat-cache": "1.3.4",
 				"object-assign": "4.1.1"
 			}
 		},
@@ -3355,17 +3404,19 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
-				"randomatic": "3.1.0",
+				"randomatic": "3.1.1",
 				"repeat-element": "1.1.3",
 				"repeat-string": "1.6.1"
 			}
@@ -3380,16 +3431,22 @@
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
+				"rimraf": "2.6.3",
 				"write": "0.2.1"
 			}
+		},
+		"flatted": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -3402,6 +3459,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -3419,25 +3477,14 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
-				"combined-stream": "1.0.6",
-				"mime-types": "2.1.20"
-			},
-			"dependencies": {
-				"combined-stream": {
-					"version": "1.0.6",
-					"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-					"dev": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
-				}
+				"combined-stream": "1.0.7",
+				"mime-types": "2.1.21"
 			}
 		},
 		"fragment-cache": {
@@ -3455,7 +3502,7 @@
 			"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"jsonfile": "4.0.0",
 				"universalify": "0.1.2"
 			}
@@ -3473,14 +3520,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.11.1",
-				"node-pre-gyp": "0.10.0"
+				"nan": "2.12.1",
+				"node-pre-gyp": "0.10.3"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3501,7 +3548,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3525,7 +3572,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3561,7 +3608,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3584,7 +3631,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "2.3.5"
 					}
 				},
 				"fs.realpath": {
@@ -3606,11 +3653,11 @@
 						"signal-exit": "3.0.2",
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"wide-align": "1.1.3"
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3630,7 +3677,7 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3696,21 +3743,21 @@
 					"dev": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.3"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "2.3.5"
 					}
 				},
 				"mkdirp": {
@@ -3728,32 +3775,32 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
+						"iconv-lite": "0.4.24",
 						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.3",
 						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
+						"needle": "2.2.4",
 						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
+						"npm-packlist": "1.2.0",
 						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"rc": "1.2.8",
+						"rimraf": "2.6.3",
+						"semver": "5.6.0",
+						"tar": "4.4.8"
 					}
 				},
 				"nopt": {
@@ -3767,19 +3814,19 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"npm-bundled": "1.0.5"
 					}
 				},
 				"npmlog": {
@@ -3788,7 +3835,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
+						"are-we-there-yet": "1.1.5",
 						"console-control-strings": "1.1.0",
 						"gauge": "2.7.4",
 						"set-blocking": "2.0.0"
@@ -3848,12 +3895,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.5.1",
+						"deep-extend": "0.6.0",
 						"ini": "1.3.5",
 						"minimist": "1.2.0",
 						"strip-json-comments": "2.0.1"
@@ -3877,22 +3924,22 @@
 						"inherits": "2.0.3",
 						"isarray": "1.0.0",
 						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
+						"safe-buffer": "5.1.2",
 						"string_decoder": "1.1.1",
 						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true
 				},
@@ -3909,7 +3956,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3942,7 +3989,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"strip-ansi": {
@@ -3960,18 +4007,18 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
+						"chownr": "1.1.1",
 						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
+						"minipass": "2.3.5",
+						"minizlib": "1.2.1",
 						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.3"
 					}
 				},
 				"util-deprecate": {
@@ -3981,7 +4028,7 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3995,7 +4042,7 @@
 					"dev": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true
 				}
@@ -4027,7 +4074,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
@@ -4071,6 +4118,7 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -4100,6 +4148,34 @@
 				"ini": "1.3.5"
 			}
 		},
+		"global-modules": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"dev": true,
+			"requires": {
+				"global-prefix": "3.0.0"
+			}
+		},
+		"global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"dev": true,
+			"requires": {
+				"ini": "1.3.5",
+				"kind-of": "6.0.2",
+				"which": "1.3.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -4107,23 +4183,36 @@
 			"dev": true
 		},
 		"globby": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-9.0.0.tgz",
+			"integrity": "sha512-q0qiO/p1w/yJ0hk8V9x1UXlgsXUxlGd0AHUOXZVXBO6aznDtpx7M8D1kBrCAItoPm+4l8r6ATXV1JpjY2SBQOw==",
 			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
-				"arrify": "1.0.1",
+				"dir-glob": "2.2.2",
+				"fast-glob": "2.2.6",
 				"glob": "7.1.3",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"ignore": "4.0.6",
+				"pify": "4.0.1",
+				"slash": "2.0.0"
 			},
 			"dependencies": {
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
 				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 					"dev": true
 				}
 			}
@@ -4145,7 +4234,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
 					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
 					"dev": true
 				}
@@ -4153,7 +4242,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
@@ -4171,15 +4260,15 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+			"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
 			"dev": true,
 			"requires": {
 				"async": "2.6.1",
@@ -4203,13 +4292,39 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
+				"ajv": "6.8.1",
 				"har-schema": "2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.8.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+					"integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "2.0.1",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.4.1",
+						"uri-js": "4.2.2"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				}
 			}
 		},
 		"has": {
@@ -4325,17 +4440,30 @@
 			"dev": true
 		},
 		"htmlparser2": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0",
+				"domelementtype": "1.3.1",
 				"domhandler": "2.4.2",
 				"domutils": "1.7.0",
-				"entities": "1.1.1",
+				"entities": "1.1.2",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"readable-stream": "3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					}
+				}
 			}
 		},
 		"http-signature": {
@@ -4346,7 +4474,7 @@
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
-				"sshpk": "1.15.1"
+				"sshpk": "1.16.1"
 			}
 		},
 		"iconv-lite": {
@@ -4369,6 +4497,16 @@
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
 			"dev": true
+		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"dev": true,
+			"requires": {
+				"caller-path": "2.0.0",
+				"resolve-from": "3.0.0"
+			}
 		},
 		"import-lazy": {
 			"version": "3.1.0",
@@ -4422,8 +4560,8 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.4.2",
 				"cli-cursor": "2.1.0",
 				"cli-width": "2.2.0",
 				"external-editor": "2.2.0",
@@ -4454,9 +4592,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -4491,13 +4629,13 @@
 			"dev": true,
 			"requires": {
 				"async": "2.6.1",
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"conf": "1.4.0",
 				"inquirer": "5.2.0",
 				"lodash.debounce": "4.0.8",
 				"os-name": "2.0.1",
 				"request": "2.88.0",
-				"tough-cookie": "2.4.3",
+				"tough-cookie": "2.5.0",
 				"uuid": "3.3.2"
 			},
 			"dependencies": {
@@ -4517,9 +4655,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -4529,12 +4667,12 @@
 				},
 				"inquirer": {
 					"version": "5.2.0",
-					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
+						"ansi-escapes": "3.2.0",
+						"chalk": "2.4.2",
 						"cli-cursor": "2.1.0",
 						"cli-width": "2.2.0",
 						"external-editor": "2.2.0",
@@ -4627,7 +4765,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"binary-extensions": "1.12.0"
+				"binary-extensions": "1.13.0"
 			}
 		},
 		"is-buffer": {
@@ -4635,15 +4773,6 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -4710,13 +4839,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -4790,24 +4921,9 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
-		},
-		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
-		},
-		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"dev": true,
-			"requires": {
-				"is-path-inside": "1.0.1"
-			}
 		},
 		"is-path-inside": {
 			"version": "1.0.1",
@@ -4845,13 +4961,15 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -4954,6 +5072,7 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -4964,12 +5083,6 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
-		"js-base64": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-			"integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
-			"dev": true
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4977,9 +5090,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
 			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
@@ -5030,7 +5143,7 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
 		},
@@ -5040,7 +5153,7 @@
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "4.1.15"
 			}
 		},
 		"jsprim": {
@@ -5073,7 +5186,7 @@
 				"core-js": "2.3.0",
 				"es6-promise": "3.0.2",
 				"lie": "3.1.1",
-				"pako": "1.0.6",
+				"pako": "1.0.8",
 				"readable-stream": "2.0.6"
 			},
 			"dependencies": {
@@ -5091,7 +5204,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"dev": true,
 					"requires": {
@@ -5121,9 +5234,9 @@
 			}
 		},
 		"known-css-properties": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.8.0.tgz",
-			"integrity": "sha512-pku5zscbIr9YsA6lFU1nhFGSAXsdJtEQ2WilCL40d0YCoDofBlNohMUq32wyt7tpiiaZ09GKyLZFrB1ijx6+WA==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
+			"integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
 			"dev": true
 		},
 		"latest-version": {
@@ -5170,27 +5283,37 @@
 			}
 		},
 		"liferay-npm-bridge-generator": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.5.0.tgz",
-			"integrity": "sha512-CLcZ+Eb4FG9twLQOaStQdiacarhQEgAOa/d/hqB1JnDwGbeJL4v2ZJyMzSQwfNo3dk+7YWG/FwAlAvFzLIM4Pg==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.6.2.tgz",
+			"integrity": "sha512-1/QlIHRo695lCc1/qfcTSMqjdnkwcBTmJol06k9WpHWGOhfuyHmBApbhoa4pzpFcs2iNy/UrNcN4MLFkxHntGw==",
 			"dev": true,
 			"requires": {
 				"babel-preset-env": "1.7.0",
 				"fs-extra": "5.0.0",
-				"globby": "8.0.1",
-				"read-json-sync": "2.0.0",
+				"globby": "8.0.2",
+				"read-json-sync": "2.0.1",
 				"yargs": "11.1.0"
 			},
 			"dependencies": {
+				"dir-glob": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+					"dev": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"path-type": "3.0.0"
+					}
+				},
 				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
 					"dev": true,
 					"requires": {
 						"array-union": "1.0.2",
 						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.3",
+						"fast-glob": "2.2.6",
 						"glob": "7.1.3",
 						"ignore": "3.3.10",
 						"pify": "3.0.0",
@@ -5200,32 +5323,34 @@
 			}
 		},
 		"liferay-npm-build-tools-common": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.5.0.tgz",
-			"integrity": "sha512-WfguheLpBJvN8N/Ri/geH8z62lRq+etH5DPNZmfUvQi+Mfjsr3xX5SDPDnKsfnzQnoS/7YK1bvrIU6JPJSbsFg==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.6.2.tgz",
+			"integrity": "sha512-qQan8nw4jw0Sa8P05hKwwUUN452BVUyb2cLjejg4Mi0/VepdSvRRlKEP2KFpUggY2TixFjRH71i/YPcyddiEYg==",
 			"dev": true,
 			"requires": {
-				"read-json-sync": "2.0.0"
+				"read-json-sync": "2.0.1"
 			}
 		},
 		"liferay-npm-bundler": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler/-/liferay-npm-bundler-2.5.0.tgz",
-			"integrity": "sha512-oZcH3xZOYGsxeeTN7rK3kUSabs58ZJstOHKm8FYU9zDR1/abi852y/spt3LZI5qsi6synH9N+wATgnX+16v9Xw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler/-/liferay-npm-bundler-2.6.2.tgz",
+			"integrity": "sha512-/obq731zP3gbSqDQVAuh0PnuFacH2ed0dm1r/+tlnVtvAesbpf4XnocrF0X07404j9P6jQw6q+YgRbsy5dVu8g==",
 			"dev": true,
 			"requires": {
 				"babel-core": "6.26.3",
-				"data-urls": "1.0.1",
+				"data-urls": "1.1.0",
+				"dot-prop": "4.2.0",
 				"fs-extra": "4.0.3",
 				"globby": "6.1.0",
 				"insight": "0.10.0",
 				"jszip": "3.1.5",
-				"liferay-npm-build-tools-common": "2.5.0",
-				"liferay-npm-bundler-preset-standard": "2.5.0",
+				"liferay-npm-build-tools-common": "2.6.2",
+				"liferay-npm-bundler-preset-standard": "2.6.2",
 				"pretty-time": "0.2.0",
 				"read-json-sync": "1.1.1",
-				"resolve": "1.8.1",
-				"semver": "5.6.0"
+				"resolve": "1.10.0",
+				"semver": "5.6.0",
+				"xml-js": "1.6.9"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -5234,7 +5359,7 @@
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
+						"graceful-fs": "4.1.15",
 						"jsonfile": "4.0.0",
 						"universalify": "0.1.2"
 					}
@@ -5264,50 +5389,60 @@
 					"integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "4.1.15"
 					}
 				}
 			}
 		},
 		"liferay-npm-bundler-plugin-exclude-imports": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.5.0.tgz",
-			"integrity": "sha512-KbZECbH3HRRV2BiXir7iGVjXqH2b9RfO12YfSR4Z9FjQMOkZdyAKw4t7yi8JC8Om3/ccw4Qz4mZRphQX4JM7Zw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.6.2.tgz",
+			"integrity": "sha512-lI1TfCK7LnHudk7AO5unvgY9qdmKN3ArF8FXaoFfU2KtA79hlnanRh/NYNG5zqZ6JMwfLP+HUa9bKlgPEhgfpQ==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"liferay-npm-build-tools-common": "2.6.2"
 			}
 		},
 		"liferay-npm-bundler-plugin-inject-imports-dependencies": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.5.0.tgz",
-			"integrity": "sha512-55BIIu7qt5RkEtR4olokWqT1eiOYkTuDkhUyv91xSKKY8GUZg8V93kgc2sTxlBbAyWpmsN2o5EcTHzfMx/W23A==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.6.2.tgz",
+			"integrity": "sha512-9hK5nK/mPy+kXB3mAf2knBLqqh6QZ2xUgLnW1kolUaJCV0iAV52z3+q+1+SrfJpzIpYAHJK70ICff6fpeC6Z7g==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"liferay-npm-build-tools-common": "2.6.2"
 			}
 		},
 		"liferay-npm-bundler-plugin-inject-peer-dependencies": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.5.0.tgz",
-			"integrity": "sha512-rGvrvEDrM2fMEcfBnYuvXuxitmorTZ5GF22D317cXYtgtiQw1CzGSRhCBU1sz2yAh457bSVrqFs1d/26IqTzTg==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.6.2.tgz",
+			"integrity": "sha512-zCyMRd9VQAsE84D0QqQ4z85zFjY1f0qyHmOYIN7AUgDZcYdTKqBV/rYE6z1g7Doz0svmc1AvSyu34ZK9s4w0Yw==",
 			"dev": true,
 			"requires": {
-				"globby": "8.0.1",
-				"liferay-npm-build-tools-common": "2.5.0",
-				"read-json-sync": "2.0.0",
-				"resolve": "1.8.1"
+				"globby": "8.0.2",
+				"liferay-npm-build-tools-common": "2.6.2",
+				"read-json-sync": "2.0.1",
+				"resolve": "1.10.0"
 			},
 			"dependencies": {
+				"dir-glob": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+					"dev": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"path-type": "3.0.0"
+					}
+				},
 				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
 					"dev": true,
 					"requires": {
 						"array-union": "1.0.2",
 						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.3",
+						"fast-glob": "2.2.6",
 						"glob": "7.1.3",
 						"ignore": "3.3.10",
 						"pify": "3.0.0",
@@ -5317,47 +5452,61 @@
 			}
 		},
 		"liferay-npm-bundler-plugin-namespace-packages": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.5.0.tgz",
-			"integrity": "sha512-Qu4+OaKHwR0abQOJMWMUQyEJBAkpq+KgjAOgxgoK2o6YEzZFD5sX2nkT3uMDCVO6QkNUq3Y2yu0tRcmyML6KAQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.6.2.tgz",
+			"integrity": "sha512-aNzcGifoosYbnEXOPYUpgZZaBeAz5BuTRRPk178rsvJcShs8MjmmdOkIBO3HUeFwqAV3STLV5Lk9jUXVep4nlA==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"liferay-npm-build-tools-common": "2.6.2"
 			}
 		},
 		"liferay-npm-bundler-plugin-replace-browser-modules": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.5.0.tgz",
-			"integrity": "sha512-O8tOfVCAc6OBFZJSx4f1j8aCtXMkplpnnbd13WHL3RXRvVUAvlptayP2EwesV1nMfPOc5aNTSUFmmnkOlmM2gA==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.6.2.tgz",
+			"integrity": "sha512-uQWgp2Ge4oXk9N1PgdgVcEe4kCCU61Uxa3TSjrJxXF2aG/+xvKW36yH26wqDOi/40hz68V08c+rWjBZ/4JT2kQ==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0"
+				"fs-extra": "7.0.1",
+				"liferay-npm-build-tools-common": "2.6.2"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.15",
+						"jsonfile": "4.0.0",
+						"universalify": "0.1.2"
+					}
+				}
 			}
 		},
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.5.0.tgz",
-			"integrity": "sha512-PA82LR0eW0afIJjhaBk7t43+nOFF+w1td/tGH1mA7LdEtZ4/4BqbBFfNikAXtvWuekxQPX7PltGSo3+5GJlRrg==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.6.2.tgz",
+			"integrity": "sha512-DR7ZksQZgVYxtgxwK7y2jUqsONdR0rkEoGqLnWhbHj+Cn+FBXbkvegdTBHPi4G3JrDLcYlTsB5PR7ElFB/MEOQ==",
 			"dev": true,
 			"requires": {
-				"liferay-npm-build-tools-common": "2.5.0",
-				"read-json-sync": "2.0.0",
+				"liferay-npm-build-tools-common": "2.6.2",
+				"read-json-sync": "2.0.1",
 				"semver": "5.6.0"
 			}
 		},
 		"liferay-npm-bundler-preset-standard": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.5.0.tgz",
-			"integrity": "sha512-IRTB+qy/WslEjMVq4KKGx9wpB1S6qL8LaXfAkjgE9tQs/odw8eZQLZ6dhNzzvuZfPZsJgsaWgR4JNhFST5YG9A==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.6.2.tgz",
+			"integrity": "sha512-w2u1HJdXvI6t1aFwGYTcrUoUpAR2NChMd3zERt2PgwOsVLHVDpqz87Ll31NuJNHNva9U+717f4w/Bs2DTgceRg==",
 			"dev": true,
 			"requires": {
-				"babel-preset-liferay-standard": "2.5.0",
-				"liferay-npm-bundler-plugin-exclude-imports": "2.5.0",
-				"liferay-npm-bundler-plugin-inject-imports-dependencies": "2.5.0",
-				"liferay-npm-bundler-plugin-inject-peer-dependencies": "2.5.0",
-				"liferay-npm-bundler-plugin-namespace-packages": "2.5.0",
-				"liferay-npm-bundler-plugin-replace-browser-modules": "2.5.0",
-				"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.5.0"
+				"babel-preset-liferay-standard": "2.6.2",
+				"liferay-npm-bundler-plugin-exclude-imports": "2.6.2",
+				"liferay-npm-bundler-plugin-inject-imports-dependencies": "2.6.2",
+				"liferay-npm-bundler-plugin-inject-peer-dependencies": "2.6.2",
+				"liferay-npm-bundler-plugin-namespace-packages": "2.6.2",
+				"liferay-npm-bundler-plugin-replace-browser-modules": "2.6.2",
+				"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.6.2"
 			}
 		},
 		"load-json-file": {
@@ -5366,7 +5515,7 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"parse-json": "4.0.0",
 				"pify": "3.0.0",
 				"strip-bom": "3.0.0"
@@ -5399,7 +5548,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
 					"dev": true
 				}
@@ -5416,7 +5565,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
 					"dev": true
 				}
@@ -5440,7 +5589,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1"
+				"chalk": "2.4.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5453,9 +5602,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -5506,9 +5655,9 @@
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
@@ -5564,10 +5713,11 @@
 			"dev": true
 		},
 		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true,
+			"optional": true
 		},
 		"mathml-tag-names": {
 			"version": "2.1.0",
@@ -5603,7 +5753,7 @@
 				"decamelize-keys": "1.1.0",
 				"loud-rejection": "1.6.0",
 				"minimist-options": "3.0.2",
-				"normalize-package-data": "2.4.0",
+				"normalize-package-data": "2.5.0",
 				"read-pkg-up": "3.0.0",
 				"redent": "2.0.0",
 				"trim-newlines": "2.0.0",
@@ -5617,16 +5767,16 @@
 			"dev": true
 		},
 		"metal": {
-			"version": "2.16.6",
-			"resolved": "https://registry.npmjs.org/metal/-/metal-2.16.6.tgz",
-			"integrity": "sha512-GM+W3J+MVnYtfcwQlV6R2gCpB9ydSGVlVsBhRdDcaL0/27ZJAKfygLVJY1mQVrSyMpLIwKWbeWjBM20JDMu6Dw=="
+			"version": "2.16.7",
+			"resolved": "https://registry.npmjs.org/metal/-/metal-2.16.7.tgz",
+			"integrity": "sha512-lCUB9DXNS7dVv03/Z+bLeCKaxAfES8T7qhZiFkpkQgW2lmwZrr0p8QcJ8TJPgRPr5EMUitlvVr3fKsxzjeq6mA=="
 		},
 		"metal-ajax": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/metal-ajax/-/metal-ajax-2.1.1.tgz",
 			"integrity": "sha512-r61ku32uivdaBd3joWrTiGV2kyG9Nvpt4gq4Npo/9MDWj2Tcm4xk2PZ7iKpIAF88JD4dwW+etjgK5Il3SzC9+g==",
 			"requires": {
-				"metal": "2.16.6",
+				"metal": "2.16.7",
 				"metal-promise": "2.0.1",
 				"metal-uri": "2.4.0"
 			}
@@ -5636,24 +5786,24 @@
 			"resolved": "https://registry.npmjs.org/metal-debounce/-/metal-debounce-2.0.1.tgz",
 			"integrity": "sha512-rielNpoc6dggjtfGfrmI+VByEj7vbz85c8v1OaAwPeFkwD1b9RwWCcySud0BCuOa3UrKHLOWnEiJXW1161gPTw==",
 			"requires": {
-				"core-js": "2.5.7"
+				"core-js": "2.6.4"
 			}
 		},
 		"metal-dom": {
-			"version": "2.16.6",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.16.6.tgz",
-			"integrity": "sha512-1pQi9XNp6bIsj2OGK/SAVs8OTQkg8yxvpEydO3SD4GFy8hIqsqamj4+0tRQIkv/lY1ZH5aSwxOifzNcw66jYvg==",
+			"version": "2.16.7",
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.16.7.tgz",
+			"integrity": "sha512-FbKjx8k4Jjsso96tHsUJakXK67RoEyEsOTKgqbjXZcqo4ThfbkOrJpVk/g0QXQSUk4yefQUHG/XDyTWOpZdpuw==",
 			"requires": {
-				"metal": "2.16.6",
-				"metal-events": "2.16.6"
+				"metal": "2.16.7",
+				"metal-events": "2.16.7"
 			}
 		},
 		"metal-events": {
-			"version": "2.16.6",
-			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.16.6.tgz",
-			"integrity": "sha512-cbSYAg1MZhAjIL1VLyWBv3iO/jITGEb6hh/4vpSR66kwjM8/I84MotbkgbVBhNkIpB3B9Y1eKWMBMfPyC7iWdQ==",
+			"version": "2.16.7",
+			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.16.7.tgz",
+			"integrity": "sha512-LuxsRlMTQu+Vw6yev9F38vnTPGQYimWDs8IHyvI3z6uBCyrK9jSw5prbNPn+DEjMgK5HFJtKTsPsCNF5AaNBtQ==",
 			"requires": {
-				"metal": "2.16.6"
+				"metal": "2.16.7"
 			}
 		},
 		"metal-path-parser": {
@@ -5661,15 +5811,15 @@
 			"resolved": "https://registry.npmjs.org/metal-path-parser/-/metal-path-parser-1.0.4.tgz",
 			"integrity": "sha512-qKbO7RStzujqRa2/lXqlgQ6vLpQOK+M6fRgolpQanh4+otDrANIQkLhFO8GKVSBCywMjUJyO+vwAHXrRwQsM2w==",
 			"requires": {
-				"metal": "2.16.6"
+				"metal": "2.16.7"
 			}
 		},
 		"metal-promise": {
 			"version": "2.0.1",
-			"resolved": "http://registry.npmjs.org/metal-promise/-/metal-promise-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-promise/-/metal-promise-2.0.1.tgz",
 			"integrity": "sha1-KP9DIQ5MaeX/9R2/IB5K4v5vg9U=",
 			"requires": {
-				"metal": "2.16.6"
+				"metal": "2.16.7"
 			}
 		},
 		"metal-structs": {
@@ -5677,7 +5827,7 @@
 			"resolved": "https://registry.npmjs.org/metal-structs/-/metal-structs-1.0.2.tgz",
 			"integrity": "sha512-LoGpcDtHvheGrG0e3eTPlb1vG52M06LbYtD4Oyb1EkVSMUvxpAjwuzVh4eUTkCLH9facAgoLlwkO2j07NBrdeA==",
 			"requires": {
-				"metal": "2.16.6"
+				"metal": "2.16.7"
 			}
 		},
 		"metal-uri": {
@@ -5685,7 +5835,7 @@
 			"resolved": "https://registry.npmjs.org/metal-uri/-/metal-uri-2.4.0.tgz",
 			"integrity": "sha512-Fm2cYA8yKhK3Fz4rgajtYagqzYWrdsRTSnG2x6BAaMrQlmKB0s4gEdaxSlZ29XMlaur86D1DtTr9V1Pi0dDMjQ==",
 			"requires": {
-				"metal": "2.16.6",
+				"metal": "2.16.7",
 				"metal-structs": "1.0.2",
 				"path-browserify": "0.0.0",
 				"url": "0.11.0"
@@ -5696,7 +5846,7 @@
 			"resolved": "https://registry.npmjs.org/metal-useragent/-/metal-useragent-3.0.1.tgz",
 			"integrity": "sha512-rld1rRGmis/Wt1O/d8nIeEDOBhzCzz2xvteTbsJzE+1sixoTYcCQk6cRBxFFKur6U5LUEEyC7sV4+mHndVHAgQ==",
 			"requires": {
-				"metal": "2.16.6"
+				"metal": "2.16.7"
 			}
 		},
 		"micromatch": {
@@ -5704,6 +5854,7 @@
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -5721,18 +5872,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.36.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.20",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+			"version": "2.1.21",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.36.0"
+				"mime-db": "1.37.0"
 			}
 		},
 		"mimic-fn": {
@@ -5752,7 +5903,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -5789,7 +5940,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -5809,9 +5960,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"dev": true,
 			"optional": true
 		},
@@ -5867,22 +6018,22 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.0.0-alpha.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.14.tgz",
-			"integrity": "sha512-G8nnF9cP9QPP/jUmYWw/uUUhumHmkm+X/EarCugYFjYm2uXRMFeOD6CVT3RLdoyCvDUNy51nirGfUItKWs/S1g==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.7.tgz",
+			"integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
 			"dev": true,
 			"requires": {
 				"semver": "5.6.0"
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.7.1",
-				"is-builtin-module": "1.0.0",
+				"resolve": "1.10.0",
 				"semver": "5.6.0",
 				"validate-npm-package-license": "3.0.4"
 			}
@@ -5986,11 +6137,24 @@
 				}
 			}
 		},
+		"object.fromentries": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+			"integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "1.1.3",
+				"es-abstract": "1.13.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.3"
+			}
+		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -6102,7 +6266,7 @@
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"mkdirp": "0.5.1",
 				"object-assign": "4.1.1"
 			}
@@ -6150,9 +6314,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
 			"dev": true
 		},
 		"parse-entities": {
@@ -6174,6 +6338,7 @@
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -6296,14 +6461,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-			"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+			"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"source-map": "0.6.1",
-				"supports-color": "5.5.0"
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6316,14 +6481,25 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
 						"supports-color": "5.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "3.0.0"
+							}
+						}
 					}
 				},
 				"source-map": {
@@ -6333,9 +6509,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -6344,69 +6520,39 @@
 			}
 		},
 		"postcss-html": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.34.0.tgz",
-			"integrity": "sha512-BIW982Kbf9/RikInNhNS3/GA6x/qY/+jhVS9KumqXZtU9ss8Yq15HhPJ6mnaXcU5bFq2ULxpOv96mHPAErpGMQ==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
 			"dev": true,
 			"requires": {
-				"htmlparser2": "3.9.2"
+				"htmlparser2": "3.10.0"
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.34.0.tgz",
-			"integrity": "sha512-UJISlEGWH/LeMYudAwq9GeqfyPW9AeRq87GHOlbquxOIakKr0Aqu6l9Cx0Fg20f3A9bKJcX1NGX4/xzIs7PlZQ==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
+			"integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "7.1.2",
-				"postcss-styled": "0.34.0"
+				"@babel/core": "7.2.2"
 			}
 		},
 		"postcss-less": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
-			"integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.2.tgz",
+			"integrity": "sha512-66ZBVo1JGkQ7r13M97xcHcyarWpgg21RaqIZWZXHE3XOtb5+ywK1uZWeY1DYkYRkIX/l8Hvxnx9iSKB68nFr+w==",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.9",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				}
+				"postcss": "7.0.14"
 			}
 		},
 		"postcss-markdown": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.34.0.tgz",
-			"integrity": "sha512-cKPggF9OMOKPoqDm5YpYszCqMsImFh78FK6P8p6IsEKZB6IkUJYKz0/QgadYy4jLb60jcFIHJ6v6jsMH7/ZQrA==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+			"integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
 			"dev": true,
 			"requires": {
-				"remark": "9.0.0",
+				"remark": "10.0.1",
 				"unist-util-find-all-after": "1.0.2"
 			}
 		},
@@ -6417,15 +6563,15 @@
 			"dev": true
 		},
 		"postcss-reporter": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.0.tgz",
-			"integrity": "sha512-5xQXm1UPWuFObjbtyQzWvQaupru8yFcFi4HUlm6OPo1o2bUszYASuqRJ7bVArb3svGCdbYtqdMBKrqR1Aoy+tw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"lodash": "4.17.11",
 				"log-symbols": "2.2.0",
-				"postcss": "7.0.5"
+				"postcss": "7.0.14"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6438,9 +6584,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -6471,17 +6617,17 @@
 			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "7.0.5"
+				"postcss": "7.0.14"
 			}
 		},
 		"postcss-sass": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.3.tgz",
-			"integrity": "sha512-uoRhfwZJHDRI8p2KQniTx4UwzYwKgQUhmFNJ7aysL3+tgFUfmv5TPX8UPnlE5gfrq6KHUUwPJ/nISFtzwxr7iQ==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+			"integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
 			"dev": true,
 			"requires": {
 				"gonzales-pe": "4.2.3",
-				"postcss": "7.0.5"
+				"postcss": "7.0.14"
 			}
 		},
 		"postcss-scss": {
@@ -6490,7 +6636,7 @@
 			"integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
 			"dev": true,
 			"requires": {
-				"postcss": "7.0.5"
+				"postcss": "7.0.14"
 			}
 		},
 		"postcss-selector-parser": {
@@ -6524,9 +6670,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -6540,7 +6686,7 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
+						"chalk": "2.4.2",
 						"source-map": "0.6.1",
 						"supports-color": "5.5.0"
 					}
@@ -6562,16 +6708,10 @@
 				}
 			}
 		},
-		"postcss-styled": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.34.0.tgz",
-			"integrity": "sha512-Uaeetr/xOiQWGJgzPFOr32/Bwykpfh9TVE26OpmwDb8eEN205TS/gqkt9ri+C6otQzQKXqbMfeZNbKYi7QpeNA==",
-			"dev": true
-		},
 		"postcss-syntax": {
-			"version": "0.34.0",
-			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.34.0.tgz",
-			"integrity": "sha512-L36NZwq2UK743US+vl1CRMdBRZCBmFYfThP9n9jCFhX1Wfk6BqnRSgt0Fy8q44IwxPee/GCzlo7T1c1JIeUDlQ==",
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
 			"dev": true
 		},
 		"postcss-value-parser": {
@@ -6596,7 +6736,8 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"pretty-time": {
 			"version": "0.2.0",
@@ -6621,9 +6762,9 @@
 			"dev": true
 		},
 		"progress": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
 		"prop-types": {
@@ -6643,9 +6784,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
 			"dev": true
 		},
 		"punycode": {
@@ -6671,27 +6812,30 @@
 			"dev": true
 		},
 		"randomatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-number": "4.0.0",
 				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
+				"math-random": "1.0.4"
 			},
 			"dependencies": {
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
 					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6709,20 +6853,17 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
 			}
 		},
 		"read-json-sync": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-2.0.0.tgz",
-			"integrity": "sha512-3w/Gh40X24GJACTWhbs9d7adcLTeQ+/6RgDN4Tq2lmwgLFC7cdBmEZt/uPg2HqL1Le64zrvAQpQlP7QxGFDI+A==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-2.0.1.tgz",
+			"integrity": "sha512-8ZJRyVJ6jKMzXsuoTTb/LPQusL/bNdNZi1GV5cZ8m9JSvHGIfI7caizhNOPkLVaZWGUrARc88cAftSnRE1liDg==",
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -6731,7 +6872,7 @@
 			"dev": true,
 			"requires": {
 				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.4.0",
+				"normalize-package-data": "2.5.0",
 				"path-type": "3.0.0"
 			}
 		},
@@ -6747,7 +6888,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -6767,7 +6908,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"micromatch": "3.1.10",
 				"readable-stream": "2.3.6"
 			},
@@ -7110,6 +7251,7 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
@@ -7126,7 +7268,7 @@
 		},
 		"regexpp": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
 			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
 			"dev": true
 		},
@@ -7184,20 +7326,20 @@
 			}
 		},
 		"remark": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
-			"integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+			"integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
 			"dev": true,
 			"requires": {
-				"remark-parse": "5.0.0",
-				"remark-stringify": "5.0.0",
-				"unified": "6.2.0"
+				"remark-parse": "6.0.3",
+				"remark-stringify": "6.0.4",
+				"unified": "7.1.0"
 			}
 		},
 		"remark-parse": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
 			"dev": true,
 			"requires": {
 				"collapse-white-space": "1.0.4",
@@ -7213,14 +7355,14 @@
 				"trim-trailing-lines": "1.1.1",
 				"unherit": "1.1.1",
 				"unist-util-remove-position": "1.1.2",
-				"vfile-location": "2.0.3",
+				"vfile-location": "2.0.4",
 				"xtend": "4.0.1"
 			}
 		},
 		"remark-stringify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-			"integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+			"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
 			"dev": true,
 			"requires": {
 				"ccount": "1.0.3",
@@ -7284,13 +7426,13 @@
 				"combined-stream": "1.0.7",
 				"extend": "3.0.2",
 				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.1.0",
+				"form-data": "2.3.3",
+				"har-validator": "5.1.3",
 				"http-signature": "1.2.0",
 				"is-typedarray": "1.0.0",
 				"isstream": "0.1.2",
 				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.20",
+				"mime-types": "2.1.21",
 				"oauth-sign": "0.9.0",
 				"performance-now": "2.1.0",
 				"qs": "6.5.2",
@@ -7298,6 +7440,24 @@
 				"tough-cookie": "2.4.3",
 				"tunnel-agent": "0.6.0",
 				"uuid": "3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "1.1.31",
+						"punycode": "1.4.1"
+					}
+				}
 			}
 		},
 		"require-directory": {
@@ -7320,21 +7480,44 @@
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
+			},
+			"dependencies": {
+				"caller-path": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+					"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+					"dev": true,
+					"requires": {
+						"callsites": "0.2.0"
+					}
+				},
+				"callsites": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+					"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+					"dev": true
+				}
 			}
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"dev": true,
 			"requires": {
 				"path-parse": "1.0.6"
 			}
 		},
 		"resolve-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 			"dev": true
 		},
 		"resolve-url": {
@@ -7360,9 +7543,9 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
 				"glob": "7.1.3"
@@ -7381,7 +7564,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
 					"dev": true
 				}
@@ -7441,6 +7624,12 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -7457,16 +7646,16 @@
 			}
 		},
 		"senna": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/senna/-/senna-2.7.3.tgz",
-			"integrity": "sha512-OIu/gdBRbfXA+W/xnt7yorL1y28vU5xeGJcafFKNkAd1PlHTAvLKdQ6H43+INDBqeZISllwKR59/PXWwoDzOQA==",
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/senna/-/senna-2.7.4.tgz",
+			"integrity": "sha512-v4QJLGuVaW4tniovgUglJBlS2zyP7kYXuYnfqGS5FLBkSI8yoxCu4m2OXZdhHd4c4JdXIsPF2tWVmGLVAgbySA==",
 			"requires": {
-				"bootstrap": "3.3.7",
-				"metal": "2.16.6",
+				"bootstrap": "3.4.0",
+				"metal": "2.16.7",
 				"metal-ajax": "2.1.1",
 				"metal-debounce": "2.0.1",
-				"metal-dom": "2.16.6",
-				"metal-events": "2.16.6",
+				"metal-dom": "2.16.7",
+				"metal-events": "2.16.7",
 				"metal-path-parser": "1.0.4",
 				"metal-promise": "2.0.1",
 				"metal-structs": "1.0.2",
@@ -7682,13 +7871,13 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-license-ids": "3.0.3"
 			}
 		},
 		"spdx-exceptions": {
@@ -7704,13 +7893,13 @@
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "2.2.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-license-ids": "3.0.3"
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
 			"dev": true
 		},
 		"specificity": {
@@ -7735,9 +7924,9 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-			"integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "0.2.4",
@@ -7834,7 +8023,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
@@ -7872,63 +8061,64 @@
 			"dev": true
 		},
 		"stylelint": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.6.0.tgz",
-			"integrity": "sha512-Q0UcbFPRiC+3FejNyIBAWbMuKwZNAC0kvZtGQbjwA9LMKDod6xMlBsiIigQxmE3ywpmTeFj3mkG5Jj36EfC7XA==",
+			"version": "9.10.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
+			"integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "9.2.0",
+				"autoprefixer": "9.4.7",
 				"balanced-match": "1.0.0",
-				"chalk": "2.4.1",
-				"cosmiconfig": "5.0.6",
-				"debug": "4.1.0",
+				"chalk": "2.4.2",
+				"cosmiconfig": "5.0.7",
+				"debug": "4.1.1",
 				"execall": "1.0.0",
-				"file-entry-cache": "2.0.0",
+				"file-entry-cache": "4.0.0",
 				"get-stdin": "6.0.0",
-				"globby": "8.0.1",
+				"global-modules": "2.0.0",
+				"globby": "9.0.0",
 				"globjoin": "0.1.4",
 				"html-tags": "2.0.0",
-				"ignore": "4.0.6",
+				"ignore": "5.0.5",
 				"import-lazy": "3.1.0",
 				"imurmurhash": "0.1.4",
-				"known-css-properties": "0.8.0",
+				"known-css-properties": "0.11.0",
 				"leven": "2.1.0",
 				"lodash": "4.17.11",
 				"log-symbols": "2.2.0",
 				"mathml-tag-names": "2.1.0",
 				"meow": "5.0.0",
-				"micromatch": "2.3.11",
+				"micromatch": "3.1.10",
 				"normalize-selector": "0.2.0",
-				"pify": "4.0.0",
-				"postcss": "7.0.5",
-				"postcss-html": "0.34.0",
-				"postcss-jsx": "0.34.0",
-				"postcss-less": "2.0.0",
-				"postcss-markdown": "0.34.0",
+				"pify": "4.0.1",
+				"postcss": "7.0.14",
+				"postcss-html": "0.36.0",
+				"postcss-jsx": "0.36.0",
+				"postcss-less": "3.1.2",
+				"postcss-markdown": "0.36.0",
 				"postcss-media-query-parser": "0.2.3",
-				"postcss-reporter": "6.0.0",
+				"postcss-reporter": "6.0.1",
 				"postcss-resolve-nested-selector": "0.1.1",
 				"postcss-safe-parser": "4.0.1",
-				"postcss-sass": "0.3.3",
+				"postcss-sass": "0.3.5",
 				"postcss-scss": "2.0.0",
 				"postcss-selector-parser": "3.1.1",
-				"postcss-styled": "0.34.0",
-				"postcss-syntax": "0.34.0",
+				"postcss-syntax": "0.36.2",
 				"postcss-value-parser": "3.3.1",
 				"resolve-from": "4.0.0",
 				"signal-exit": "3.0.2",
+				"slash": "2.0.0",
 				"specificity": "0.4.1",
-				"string-width": "2.1.1",
+				"string-width": "3.0.0",
 				"style-search": "0.1.0",
 				"sugarss": "2.0.0",
 				"svg-tags": "1.0.0",
-				"table": "5.1.0"
+				"table": "5.2.2"
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+					"version": "6.8.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+					"integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "2.0.1",
@@ -7936,6 +8126,12 @@
 						"json-schema-traverse": "0.4.1",
 						"uri-js": "4.2.2"
 					}
+				},
+				"ansi-regex": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
@@ -7946,10 +8142,51 @@
 						"color-convert": "1.9.3"
 					}
 				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -7958,12 +8195,155 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
 					}
 				},
 				"fast-deep-equal": {
@@ -7972,39 +8352,108 @@
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
-				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+				"file-entry-cache": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
+					"integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.3",
-						"glob": "7.1.3",
-						"ignore": "3.3.10",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
+						"flat-cache": "2.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
-						"ignore": {
-							"version": "3.3.10",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-							"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-							"dev": true
-						},
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
 						}
 					}
 				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
 				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"dev": true
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"json-schema-traverse": {
@@ -8013,6 +8462,33 @@
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
 				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -8020,9 +8496,9 @@
 					"dev": true
 				},
 				"pify": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz",
-					"integrity": "sha512-zrSP/KDf9DH3K3VePONoCstgPiYJy9z0SCatZuTpOc7YdnWIqwkWdXOuwlr4uDc7em8QZRsFWsT/685x5InjYg==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				},
 				"resolve-from": {
@@ -8030,6 +8506,43 @@
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"astral-regex": "1.0.0",
+						"is-fullwidth-code-point": "2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+					"integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "7.0.3",
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "5.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "4.0.0"
+					}
 				},
 				"supports-color": {
 					"version": "5.5.0",
@@ -8041,15 +8554,51 @@
 					}
 				},
 				"table": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
-					"integrity": "sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==",
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/table/-/table-5.2.2.tgz",
+					"integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
 					"dev": true,
 					"requires": {
-						"ajv": "6.5.4",
+						"ajv": "6.8.1",
 						"lodash": "4.17.11",
-						"slice-ansi": "1.0.0",
+						"slice-ansi": "2.1.0",
 						"string-width": "2.1.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "2.0.0",
+								"strip-ansi": "4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "0.5.1"
 					}
 				}
 			}
@@ -8075,9 +8624,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -8091,7 +8640,7 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
+						"chalk": "2.4.2",
 						"source-map": "0.6.1",
 						"supports-color": "5.5.0"
 					}
@@ -8119,7 +8668,7 @@
 			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "7.0.5"
+				"postcss": "7.0.14"
 			}
 		},
 		"supports-color": {
@@ -8148,7 +8697,7 @@
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"lodash": "4.17.11",
 				"slice-ansi": "1.0.0",
 				"string-width": "2.1.1"
@@ -8164,9 +8713,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -8208,7 +8757,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -8276,19 +8825,19 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "1.1.31",
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				}
 			}
@@ -8408,16 +8957,18 @@
 			}
 		},
 		"unified": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
 			"dev": true,
 			"requires": {
+				"@types/unist": "2.0.2",
+				"@types/vfile": "3.0.2",
 				"bail": "1.0.3",
 				"extend": "3.0.2",
 				"is-plain-obj": "1.1.0",
 				"trough": "1.0.3",
-				"vfile": "2.3.0",
+				"vfile": "3.0.1",
 				"x-is-string": "0.1.0"
 			}
 		},
@@ -8584,7 +9135,7 @@
 			"dev": true,
 			"requires": {
 				"boxen": "1.3.0",
-				"chalk": "2.4.1",
+				"chalk": "2.4.2",
 				"configstore": "3.1.2",
 				"import-lazy": "2.1.0",
 				"is-ci": "1.2.1",
@@ -8605,9 +9156,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -8712,7 +9263,7 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.2",
+				"spdx-correct": "3.1.0",
 				"spdx-expression-parse": "3.0.0"
 			}
 		},
@@ -8728,27 +9279,35 @@
 			}
 		},
 		"vfile": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6",
+				"is-buffer": "2.0.3",
 				"replace-ext": "1.0.0",
 				"unist-util-stringify-position": "1.1.2",
-				"vfile-message": "1.0.1"
+				"vfile-message": "1.1.1"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"dev": true
+				}
 			}
 		},
 		"vfile-location": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
-			"integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
 			"dev": true
 		},
 		"vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
 			"dev": true,
 			"requires": {
 				"unist-util-stringify-position": "1.1.2"
@@ -8761,9 +9320,9 @@
 			"dev": true
 		},
 		"whatwg-mimetype": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
 			"dev": true
 		},
 		"whatwg-url": {
@@ -8793,9 +9352,9 @@
 			"dev": true
 		},
 		"widest-line": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
 			"dev": true,
 			"requires": {
 				"string-width": "2.1.1"
@@ -8818,7 +9377,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
@@ -8864,12 +9423,12 @@
 			}
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+			"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
+				"graceful-fs": "4.1.15",
 				"imurmurhash": "0.1.4",
 				"signal-exit": "3.0.2"
 			}
@@ -8885,6 +9444,15 @@
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
 			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
 			"dev": true
+		},
+		"xml-js": {
+			"version": "1.6.9",
+			"resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.9.tgz",
+			"integrity": "sha512-Omi8lVfq3q3H0xnGcZKLQhoiOghTGN1xxfabah4FybYN1pyvUzh1X+cJ+vKKY3Zr255y1H5IUAT3u3lznshdbw==",
+			"dev": true,
+			"requires": {
+				"sax": "1.2.4"
+			}
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -8906,7 +9474,7 @@
 		},
 		"yargs": {
 			"version": "11.1.0",
-			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -14,7 +14,7 @@
 		"metal": "^2.4.7",
 		"metal-dom": "^2.4.7",
 		"metal-uri": "^2.0.2",
-		"senna": "2.7.3"
+		"senna": "2.7.4"
 	},
 	"devDependencies": {
 		"babel-cli": "6.26.0",

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/screen/EventScreen.es.js
@@ -295,28 +295,6 @@ class EventScreen extends HtmlScreen {
 		}
 	}
 
-	/**
-	 * Adds the type attribute with 'image/x-icon' when the favicon is an icon,
-	 * this ensures that it works fine in IE 11.
-	 * @param {!Array<Element>} elements
-	 * @private
-	 * @return {CancellablePromise}
-	 */
-
-	runFaviconInElement_(elements) {
-		return super.runFaviconInElement_(elements).then(
-			() => {
-				elements.forEach(
-					element => {
-						if (!element.type && element.href.indexOf('.ico') !== -1) {
-							element.type = 'image/x-icon';
-						}
-					}
-				);
-			}
-		);
-	}
-
 }
 
 export default EventScreen;

--- a/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
+++ b/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
@@ -14,7 +14,8 @@
 
 package com.liferay.frontend.theme.favicon.servlet.internal;
 
-import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.IOException;
@@ -46,10 +47,9 @@ public class FaviconServlet extends HttpServlet {
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException, ServletException {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		Object contextPathObject = request.getAttribute("CURRENT_URL");
 
-		String contextPath = request.getAttribute("CURRENT_URL").toString();
+		String contextPath = contextPathObject.toString();
 
 		if (!contextPath.equals("/o/favicon.ico")) {
 			contextPath = contextPath.replace("/favicon", "");
@@ -57,6 +57,17 @@ public class FaviconServlet extends HttpServlet {
 			response.sendRedirect(contextPath + "/images/favicon.ico");
 
 			return;
+		}
+
+		LayoutSet layoutSet = (LayoutSet)request.getAttribute(
+			WebKeys.VIRTUAL_HOST_LAYOUT_SET);
+
+		if (layoutSet != null) {
+			Theme theme = layoutSet.getTheme();
+
+			response.sendRedirect(
+				theme.getContextPath() + theme.getImagesPath() +
+					"/favicon.ico");
 		}
 	}
 

--- a/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
+++ b/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
@@ -51,21 +51,14 @@ public class FaviconServlet extends HttpServlet {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (themeDisplay != null) {
-			response.sendRedirect(themeDisplay.getPathImage() + "/favicon.ico");
+		String contextPath = request.getAttribute("CURRENT_URL").toString();
+
+		if(!contextPath.equals("/o/favicon.ico")) {
+			contextPath = contextPath.replace("/favicon", "");
+
+			response.sendRedirect(contextPath + "/images/favicon.ico");
 
 			return;
-		}
-
-		LayoutSet layoutSet = (LayoutSet)request.getAttribute(
-			WebKeys.VIRTUAL_HOST_LAYOUT_SET);
-
-		if (layoutSet != null) {
-			Theme theme = layoutSet.getTheme();
-
-			response.sendRedirect(
-				theme.getContextPath() + theme.getImagesPath() +
-					"/favicon.ico");
 		}
 	}
 

--- a/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
+++ b/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
@@ -14,8 +14,6 @@
 
 package com.liferay.frontend.theme.favicon.servlet.internal;
 
-import com.liferay.portal.kernel.model.LayoutSet;
-import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -53,7 +51,7 @@ public class FaviconServlet extends HttpServlet {
 
 		String contextPath = request.getAttribute("CURRENT_URL").toString();
 
-		if(!contextPath.equals("/o/favicon.ico")) {
+		if (!contextPath.equals("/o/favicon.ico")) {
 			contextPath = contextPath.replace("/favicon", "");
 
 			response.sendRedirect(contextPath + "/images/favicon.ico");

--- a/portal-web/docroot/WEB-INF/urlrewrite.xml
+++ b/portal-web/docroot/WEB-INF/urlrewrite.xml
@@ -7,8 +7,8 @@
 		<to type="redirect">%{context-path}/webdav$1</to>
 	</rule>
 	<rule>
-		<from>^/favicon.ico$</from>
-		<to type="redirect">/o/favicon/</to>
+		<from>^/favicon.ico(.*)$</from>
+		<to type="redirect">/o/favicon$1</to>
 	</rule>
 	<rule>
 		<from>^/(.{1,1000}/)?blog/blogs/rss(.{0,1000})</from>

--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -20,7 +20,13 @@
 
 <liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
 
-<link href="<%= BrowserSnifferUtil.isIe(request) ? StringPool.BLANK : themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
+<c:if test="<%= BrowserSnifferUtil.isIe(request) %>">
+	<link href="/<%= PropsValues.THEME_SHORTCUT_ICON %>/<%= themeDisplay.getTheme().getServletContextName() %>" rel="icon" />
+</c:if>
+
+<c:if test="<%= !BrowserSnifferUtil.isIe(request) %>">
+	<link href="<%= themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
+</c:if>
 
 <%-- Available Translations --%>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88702

[**top_head.jsp**](https://github.com/liferay/liferay-portal/compare/master...fortunatomaldonado:LPP-32508?expand=1#diff-efb09d4c2f1c6a7bbdd4fc5f72c2b651): Changed the link for IE. Adding the ServletContextName of the current theme in the link so the FaviconServlet can use it. 

[**urlrewrite.xml**](https://github.com/liferay/liferay-portal/compare/master...fortunatomaldonado:LPP-32508?expand=1#diff-26de098c8f7c80808dbc3ef437d7f65f): Change the regrex to add to the changed link but keep format.

[**FaviconServlet.java**](https://github.com/fortunatomaldonado/liferay-portal/commit/54193a8932fb49fc3ee5a19995608d90269e0e59#diff-3cde598b507c3580481d510c646603d5): Get the contextPath from the CURRENT_URL and use it to find the favicon.ico of the theme. In IE, the favicon should now be able to be found due to these changes.

**Other Issue**: If you enter /favicon.ico the favicon will not be displayed because we do not have any indication of which theme is being used. Previously, the default theme favicon would display since it contained the default theme information in the LayoutSet. This is another issue that needs to be figured out.

[**EventScreen.es.js**](https://github.com/fortunatomaldonado/liferay-portal/commit/54193a8932fb49fc3ee5a19995608d90269e0e59#diff-a62a35b9653d35b3f6ca6af0a92fb777): Removed method to prevent adding ?q= in the link. Whenever the query was being added to the link, the favicon would not appear. After removing this I was able to get the favicon to appear correctly. I believe this is no longer needed but I could be wrong. There was a time where the query reappeared but it might have been due to caching issue. I was able to find [HtmlScreen.js ](https://github.com/liferay/senna.js/blob/master/src/screen/HtmlScreen.js#L301-L314) in Senna which adds the query and think this may cause an issue.

Let me know if there are any questions or comments about this.
Thank you again for your help!