### PR TITLE
LPS-117248 Fixes error when trying to edit a FieldSet object field

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/AppContext.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/AppContext.es.js
@@ -289,7 +289,10 @@ const createReducer = (dataLayoutBuilder) => {
 						focusedCustomObjectField,
 					}
 				);
-				const {settingsContext} = editedFocusedCustomObjectField;
+				const {
+					nestedDataDefinitionFields,
+					settingsContext,
+				} = editedFocusedCustomObjectField;
 
 				return {
 					...state,
@@ -301,9 +304,12 @@ const createReducer = (dataLayoutBuilder) => {
 									dataDefinitionField.name ===
 									focusedCustomObjectField.name
 								) {
-									return dataLayoutBuilder.getDataDefinitionField(
-										editedFocusedCustomObjectField
-									);
+									return {
+										...dataLayoutBuilder.getDataDefinitionField(
+											editedFocusedCustomObjectField
+										),
+										nestedDataDefinitionFields,
+									};
 								}
 
 								return dataDefinitionField;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/actions.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/actions.es.js
@@ -105,8 +105,10 @@ export const dropFieldSet = ({
 	indexes,
 	parentFieldName,
 	useFieldName,
+	...otherProps
 }) => {
 	return {
+		...otherProps,
 		fieldName,
 		fieldSet: dataLayoutBuilder.getDDMForm(fieldSet),
 		indexes,

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/getDropHandler.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/getDropHandler.es.js
@@ -73,6 +73,7 @@ export const getDropHandler = ({dataDefinition, dataLayoutBuilder}) => {
 						fieldSet: data.fieldSet,
 						indexes,
 						parentFieldName: parentField?.fieldName,
+						properties: data.properties,
 						useFieldName: data.useFieldName,
 					})
 				);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
@@ -19,7 +19,14 @@ import {updateField} from '../util/settingsContext.es';
 import {addField} from './fieldAddedHandler.es';
 
 const handleFieldSetAdded = (props, state, event) => {
-	const {fieldSet, indexes, parentFieldName, rows, useFieldName} = event;
+	const {
+		fieldSet,
+		indexes,
+		parentFieldName,
+		properties,
+		rows,
+		useFieldName,
+	} = event;
 	const {pages} = state;
 	const visitor = new PagesVisitor(fieldSet.pages);
 	const nestedFields = [];
@@ -33,6 +40,17 @@ const handleFieldSetAdded = (props, state, event) => {
 		{skipFieldNameGeneration: false, useFieldName},
 		nestedFields
 	);
+
+	if (properties) {
+		Object.keys(properties).forEach((key) => {
+			fieldSetField = updateField(
+				props,
+				fieldSetField,
+				key,
+				properties[key]
+			);
+		});
+	}
 
 	if (fieldSet.id) {
 		fieldSetField = updateField(


### PR DESCRIPTION
This PR fixes some bugs found along the way that were not described in the ticket but that was possible to see before fixes them.

- Fixed error when editing the FieldSet using the custom object Sidebar
- Fixed error when trying to drag a custom object be it FieldSet or edited Field Group to the builder
- Fixed error when dragging or double click a FieldSet it becomes a Field Group

Fixes errors both when dragging and double-clicking, the implementations are different places.